### PR TITLE
Update deprecated Stan syntax

### DIFF
--- a/inst/stan/IBD1.stan
+++ b/inst/stan/IBD1.stan
@@ -12,13 +12,13 @@ data{
     matrix[n, p3] Z3;
     matrix[n, p4] Z4;
     matrix[n, p5] Z5;
-    real y[n];
+    array[n] real y;
     real phi;
-   int index[n];
+   array[n] int index;
   }
     parameters{
     real<lower=0> s_sigma;
-    real<lower=0> sigma[p4];
+    array[p4] real<lower=0> sigma;
     real<lower=0> s_mu;
     real mu;
     real<lower=0> s_r;
@@ -31,7 +31,7 @@ data{
     vector[p4] l;
     real<lower=0> s_gl;
     vector[p5] gl;
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -62,7 +62,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma_vec[j]);
       }

--- a/inst/stan/IBD2.stan
+++ b/inst/stan/IBD2.stan
@@ -19,15 +19,15 @@ data{
     matrix[n, p6] Z6;
     matrix[n, p7] Z7;
 
-    real y[n];
+    array[n] real y;
 
     real phi;
 
-   int index[n];
+   array[n] int index;
   }
     parameters{
     real<lower=0> s_sigma;
-    real<lower=0> sigma[p4];
+    array[p4] real<lower=0> sigma;
 
     real<lower=0> s_mu;
     real mu;
@@ -53,7 +53,7 @@ data{
     real<lower=0> s_gm;
     vector[p7] gm;
 
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -101,7 +101,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma_vec[j]);
       }

--- a/inst/stan/IBD3.stan
+++ b/inst/stan/IBD3.stan
@@ -19,15 +19,15 @@ data{
     matrix[n, p8] Z8;
     matrix[n, p9] Z9;
 
-    real y[n];
+    array[n] real y;
 
     real phi;
 
-   int index[n];
+   array[n] int index;
   }
     parameters{
     real<lower=0> s_sigma;
-    real<lower=0> sigma[p4];
+    array[p4] real<lower=0> sigma;
 
     real<lower=0> s_mu;
     real mu;
@@ -53,7 +53,7 @@ data{
     real<lower=0> s_gt;
     vector[p9] gt;
 
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -101,7 +101,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma_vec[j]);
       }

--- a/inst/stan/IBD4.stan
+++ b/inst/stan/IBD4.stan
@@ -23,15 +23,15 @@ data{
     matrix[n, p8] Z8;
     matrix[n, p9] Z9;
 
-    real y[n];
+    array[n] real y;
 
     real phi;
 
-   int index[n];
+   array[n] int index;
   }
     parameters{
     real<lower=0> s_sigma;
-    real<lower=0> sigma[p4];
+    array[p4] real<lower=0> sigma;
 
     real<lower=0> s_mu;
     real mu;
@@ -63,7 +63,7 @@ data{
     real<lower=0> s_gt;
     vector[p9] gt;
 
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -117,7 +117,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma_vec[j]);
       }

--- a/inst/stan/IBD5.stan
+++ b/inst/stan/IBD5.stan
@@ -15,7 +15,7 @@ data{
     matrix[n, p4] Z4;
     matrix[n, p5] Z5;
 
-    real y[n];
+    array[n] real y;
 
     real phi;
 
@@ -42,7 +42,7 @@ data{
     real<lower=0> s_gl;
     vector[p5] gl;
 
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -81,7 +81,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma);
       }

--- a/inst/stan/IBD6.stan
+++ b/inst/stan/IBD6.stan
@@ -23,7 +23,7 @@
     matrix[n, p7] Z7;
 
     // Phenotype vector
-    real y[n];
+    array[n] real y;
 
     // Global hyperparameter
     real phi;
@@ -67,7 +67,7 @@
     vector[p7] gm;
 
     // Defining variable to generate data from the model
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -126,7 +126,7 @@
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       // Computing log-likelihood of the observed data:
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma);

--- a/inst/stan/IBD7.stan
+++ b/inst/stan/IBD7.stan
@@ -23,7 +23,7 @@ data{
     matrix[n, p9] Z9;
 
     // Phenotype vector
-    real y[n];
+    array[n] real y;
 
     // Global hyperparameter
     real phi;
@@ -67,7 +67,7 @@ data{
     vector[p9] gt;
 
     // Defining variable to generate data from the model
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -125,7 +125,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       // Computing log-likelihood of the observed data:
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma);

--- a/inst/stan/IBD8.stan
+++ b/inst/stan/IBD8.stan
@@ -27,7 +27,7 @@ data{
     matrix[n, p9] Z9;
 
     // Phenotype vector
-    real y[n];
+    array[n] real y;
 
     // Global hyperparameter
     real phi;
@@ -79,7 +79,7 @@ data{
     vector[p9] gt;
 
     // Defining variable to generate data from the model
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -146,7 +146,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       // Computing log-likelihood of the observed data:
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma);

--- a/inst/stan/RCBD1.stan
+++ b/inst/stan/RCBD1.stan
@@ -13,15 +13,15 @@
     matrix[n, p4] Z4;
     matrix[n, p5] Z5;
 
-    real y[n];
+    array[n] real y;
 
     real phi;
 
-   int index[n];
+   array[n] int index;
   }
     parameters{
     real<lower=0> s_sigma;
-    real<lower=0> sigma[p4];
+    array[p4] real<lower=0> sigma;
 
     real<lower=0> s_mu;
     real mu;
@@ -37,7 +37,7 @@
     real<lower=0> s_gl;
     vector[p5] gl;
 
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -76,7 +76,7 @@
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma_vec[j]);
       }

--- a/inst/stan/RCBD2.stan
+++ b/inst/stan/RCBD2.stan
@@ -17,15 +17,15 @@ data{
     matrix[n, p6] Z6;
     matrix[n, p7] Z7;
 
-    real y[n];
+    array[n] real y;
 
     real phi;
 
-   int index[n];
+   array[n] int index;
   }
     parameters{
     real<lower=0> s_sigma;
-    real<lower=0> sigma[p4];
+    array[p4] real<lower=0> sigma;
 
     real<lower=0> s_mu;
     real mu;
@@ -48,7 +48,7 @@ data{
     real<lower=0> s_gm;
     vector[p7] gm;
 
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -93,7 +93,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma_vec[j]);
       }

--- a/inst/stan/RCBD3.stan
+++ b/inst/stan/RCBD3.stan
@@ -17,15 +17,15 @@ data{
     matrix[n, p8] Z8;
     matrix[n, p9] Z9;
 
-    real y[n];
+    array[n] real y;
 
     real phi;
 
-   int index[n];
+   array[n] int index;
   }
     parameters{
     real<lower=0> s_sigma;
-    real<lower=0> sigma[p4];
+    array[p4] real<lower=0> sigma;
 
     real<lower=0> s_mu;
     real mu;
@@ -48,7 +48,7 @@ data{
     real<lower=0> s_gt;
     vector[p9] gt;
 
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -93,7 +93,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma_vec[j]);
       }

--- a/inst/stan/RCBD4.stan
+++ b/inst/stan/RCBD4.stan
@@ -21,15 +21,15 @@ data{
     matrix[n, p8] Z8;
     matrix[n, p9] Z9;
 
-    real y[n];
+    array[n] real y;
 
     real phi;
 
-   int index[n];
+   array[n] int index;
   }
     parameters{
     real<lower=0> s_sigma;
-    real<lower=0> sigma[p4];
+    array[p4] real<lower=0> sigma;
 
     real<lower=0> s_mu;
     real mu;
@@ -58,7 +58,7 @@ data{
     real<lower=0> s_gt;
     vector[p9] gt;
 
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -109,7 +109,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma_vec[j]);
       }

--- a/inst/stan/RCBD5.stan
+++ b/inst/stan/RCBD5.stan
@@ -13,7 +13,7 @@ data{
     matrix[n, p4] Z4;
     matrix[n, p5] Z5;
 
-    real y[n];
+    array[n] real y;
 
     real phi;
 
@@ -37,7 +37,7 @@ data{
     real<lower=0> s_gl;
     vector[p5] gl;
 
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -73,7 +73,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma);
       }

--- a/inst/stan/RCBD6.stan
+++ b/inst/stan/RCBD6.stan
@@ -21,7 +21,7 @@ data{
     matrix[n, p7] Z7;
 
     // Phenotype vector
-    real y[n];
+    array[n] real y;
 
     // Global hyperparameter
     real phi;
@@ -61,7 +61,7 @@ data{
     vector[p7] gm;
 
     // Defining variable to generate data from the model
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -115,7 +115,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       // Computing log-likelihood of the observed data:
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma);

--- a/inst/stan/RCBD7.stan
+++ b/inst/stan/RCBD7.stan
@@ -21,7 +21,7 @@ data{
     matrix[n, p9] Z9;
 
     // Phenotype vector
-    real y[n];
+    array[n] real y;
 
     // Global hyperparameter
     real phi;
@@ -61,7 +61,7 @@ data{
     vector[p9] gt;
 
     // Defining variable to generate data from the model
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -115,7 +115,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       // Computing log-likelihood of the observed data:
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma);

--- a/inst/stan/RCBD8.stan
+++ b/inst/stan/RCBD8.stan
@@ -25,7 +25,7 @@ data{
     matrix[n, p9] Z9;
 
     // Phenotype vector
-    real y[n];
+    array[n] real y;
 
     // Global hyperparameter
     real phi;
@@ -73,7 +73,7 @@ data{
     vector[p9] gt;
 
     // Defining variable to generate data from the model
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -135,7 +135,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       // Computing log-likelihood of the observed data:
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma);

--- a/inst/stan/entrymean1.stan
+++ b/inst/stan/entrymean1.stan
@@ -9,15 +9,15 @@ data{
     matrix[n, p3] Z3;
     matrix[n, p4] Z4;
 
-    real y[n];
+    array[n] real y;
 
     real phi;
 
-   int index[n];
+   array[n] int index;
   }
     parameters{
     real<lower=0> s_sigma;
-    real<lower=0> sigma[p4];
+    array[p4] real<lower=0> sigma;
 
     real<lower=0> s_mu;
     real mu;
@@ -28,7 +28,7 @@ data{
     real<lower=0> s_l;
     vector[p4] l;
 
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -61,7 +61,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma_vec[j]);
       }

--- a/inst/stan/entrymean2.stan
+++ b/inst/stan/entrymean2.stan
@@ -9,7 +9,7 @@ data{
     matrix[n, p3] Z3;
     matrix[n, p4] Z4;
 
-    real y[n];
+    array[n] real y;
 
     real phi;
 
@@ -27,7 +27,7 @@ data{
     real<lower=0> s_l;
     vector[p4] l;
 
-    real y_gen[n];
+    array[n] real y_gen;
   }
 
   transformed parameters{
@@ -57,7 +57,7 @@ data{
   }
 
   generated quantities {
-    real y_log_like[n];
+    array[n] real y_log_like;
       for (j in 1:n) {
       y_log_like[j] = cauchy_lpdf(y[j] | expectation[j], sigma);
       }


### PR DESCRIPTION
This PR updates the Stan syntax in your package to use the new array syntax, otherwise it will fail to compile with future versions of RStan.

Let me know if you have any questions, thanks!